### PR TITLE
Throw with proper error message if query fails immediately.

### DIFF
--- a/src/ThriftSQL/Hive.php
+++ b/src/ThriftSQL/Hive.php
@@ -75,10 +75,13 @@ class Hive implements \ThriftSQL {
         'statement' => $queryCleaner->clean( $queryStr ),
         'runAsync' => true,
       ) ) );
-      return new \ThriftSQL\HiveQuery( $response, $this->_client );
     } catch ( Exception $e ) {
       throw new \ThriftSQL\Exception( $e->getMessage() );
     }
+    if ( \ThriftSQL\TStatusCode::ERROR_STATUS === $response->status->statusCode ) {
+      throw new \ThriftSQL\Exception( $response->status->errorMessage );
+    }
+    return new \ThriftSQL\HiveQuery( $response, $this->_client );
   }
 
   public function queryAndFetchAll( $queryStr ) {


### PR DESCRIPTION
When a query failed immediately (e.g. due to a compilation error in the HiveQL code) we were not providing a meaningful error message.

This made some scenarios hard to debug.