### PR TITLE
DRYer code for fetching results

### DIFF
--- a/src/ThriftSQL.php
+++ b/src/ThriftSQL.php
@@ -8,16 +8,6 @@ abstract class ThriftSQL {
   abstract public function connect();
 
   /**
-  * The simplest use case; takes a query string executes it synchronously and
-  * returns the entire result set after collecting it from the server.
-  *
-  * @param string $queryStr
-  * @return array
-  * @throws \ThriftSQL\Exception
-  */
-  abstract public function queryAndFetchAll( $queryStr );
-
-  /**
   * Sends a query string for execution on the server and returns a
   * ThriftSQLQuery object for fetching the results manually.
   *
@@ -31,6 +21,25 @@ abstract class ThriftSQL {
   * @return null
   */
   abstract public function disconnect();
+
+  /**
+  * The simplest use case; takes a query string executes it synchronously and
+  * returns the entire result set after collecting it from the server.
+  *
+  * @param string $queryStr
+  * @return array
+  * @throws \ThriftSQL\Exception
+  */
+  public function queryAndFetchAll( $queryStr ) {
+    $iterator = $this->getIterator( $queryStr );
+
+    $resultTuples = array();
+    foreach( $iterator as $rowNum => $row ) {
+      $resultTuples[] = $row;
+    }
+
+    return $resultTuples;
+  }
 
   /**
    * Gets a memory efficient iterator that you can use in a foreach loop.

--- a/src/ThriftSQL/Hive.php
+++ b/src/ThriftSQL/Hive.php
@@ -84,25 +84,6 @@ class Hive extends \ThriftSQL {
     return new \ThriftSQL\HiveQuery( $response, $this->_client );
   }
 
-  public function queryAndFetchAll( $queryStr ) {
-    try {
-      $query = $this->query( $queryStr );
-      $query->wait();
-      // Collect results
-      $resultTuples = array();
-      do {
-        $responseTuples = $query->fetch(100);
-        // No more data we're done
-        if ( empty( $responseTuples ) ) {
-          return $resultTuples;
-        }
-        $resultTuples = array_merge( $resultTuples, $responseTuples );
-      } while (true);
-    } catch( Exception $e ) {
-      throw new \ThriftSQL\Exception( $e->getMessage() );
-    }
-  }
-
   public function disconnect() {
     // Close session if we have one
     if ( null !== $this->_sessionHandle ) {

--- a/src/ThriftSQL/HiveQuery.php
+++ b/src/ThriftSQL/HiveQuery.php
@@ -48,6 +48,7 @@ class HiveQuery implements \ThriftSQLQuery {
     }
 
     $this->_ready = true;
+    return $this;
   }
 
   public function fetch( $maxRows ) {

--- a/src/ThriftSQL/Impala.php
+++ b/src/ThriftSQL/Impala.php
@@ -20,7 +20,6 @@ class Impala extends \ThriftSQL {
   }
 
   public function connect() {
-
     // Check if we have already connected
     if ( null !== $this->_client ) {
       return $this;
@@ -47,7 +46,6 @@ class Impala extends \ThriftSQL {
     }
 
     return $this;
-
   }
 
   public function query( $queryStr ) {
@@ -58,26 +56,7 @@ class Impala extends \ThriftSQL {
     }
   }
 
-  public function queryAndFetchAll( $queryStr ) {
-    try {
-      $query = $this->query( $queryStr );
-      $query->wait();
-      $result = array();
-      do {
-        $rows = $query->fetch( 100 );
-        if ( empty( $rows ) ) {
-          break;
-        }
-        $result = array_merge( $result, $rows );
-      } while ( true );
-      return $result;
-    } catch( Exception $e ) {
-      throw new \ThriftSQL\Exception( $e->getMessage() );
-    }
-  }
-
   public function disconnect() {
-
     // Clear out the client
     $this->_client = null;
 
@@ -86,6 +65,5 @@ class Impala extends \ThriftSQL {
       $this->_transport->close();
     }
     $this->_transport = null;
-
   }
 }

--- a/src/ThriftSQL/ImpalaQuery.php
+++ b/src/ThriftSQL/ImpalaQuery.php
@@ -52,6 +52,7 @@ class ImpalaQuery implements \ThriftSQLQuery {
     } while (true);
 
     $this->_ready = true;
+    return $this;
   }
 
   public function fetch( $maxRows ) {

--- a/src/ThriftSQL/Utils/Iterator.php
+++ b/src/ThriftSQL/Utils/Iterator.php
@@ -96,9 +96,8 @@ class Iterator implements \Iterator {
     }
     $this->runCount++;
 
-    $this->thriftSQLQuery = $this->thriftSQL->query( $this->queryStr );
     $this->buffer = array();
     $this->location = 0;
-    $this->thriftSQLQuery->wait();
+    $this->thriftSQLQuery = $this->thriftSQL->query( $this->queryStr )->wait();
   }
 }


### PR DESCRIPTION
With the iterator method added in #24 we can simplify the `queryAndFetchAll()` method and reuse it between both Hive and Impala implementations. This makes our code more compact and simpler.